### PR TITLE
add caller field to entry

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -40,6 +44,10 @@ type Entry struct {
 
 	// Message passed to Debug, Info, Warn, Error, Fatal or Panic
 	Message string
+
+	// Caller passed to Debug, Info, Warn, Error, Fatal or Panic.
+	// To indicates where the log call came from and formats it for output.
+	Caller string
 
 	// When formatter is called in entry.log(), a Buffer may be set to entry
 	Buffer *bytes.Buffer
@@ -107,6 +115,7 @@ func (entry Entry) log(level Level, msg string) {
 
 	entry.Level = level
 	entry.Message = msg
+	entry.Caller = context()
 
 	entry.fireHooks()
 
@@ -297,4 +306,13 @@ func (entry *Entry) Panicln(args ...interface{}) {
 func (entry *Entry) sprintlnn(args ...interface{}) string {
 	msg := fmt.Sprintln(args...)
 	return msg[:len(msg)-1]
+}
+
+// Captures where the log call came from and formats it for output.
+func context() string {
+	if _, file, line, ok := runtime.Caller(4); ok {
+		return strings.Join([]string{filepath.Base(file), strconv.Itoa(line)}, ":")
+	}
+
+	return "unavailable"
 }

--- a/example_basic_test.go
+++ b/example_basic_test.go
@@ -62,10 +62,10 @@ func Example_basic() {
 	}).Panic("It's over 9000!")
 
 	// Output:
-	// level=debug msg="Started observing beach" animal=walrus number=8
-	// level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
-	// level=warning msg="The group's number increased tremendously!" number=122 omg=true
-	// level=debug msg="Temperature changes" temperature=-4
-	// level=panic msg="It's over 9000!" animal=orca size=9009
-	// level=error msg="The ice breaks!" err_animal=orca err_level=panic err_message="It's over 9000!" err_size=9009 number=100 omg=true
+	// level=debug msg="Started observing beach" caller="example.go:121" animal=walrus number=8
+	// level=info msg="A group of walrus emerges from the ocean" caller="example.go:121" animal=walrus size=10
+	// level=warning msg="The group's number increased tremendously!" caller="example.go:121" number=122 omg=true
+	// level=debug msg="Temperature changes" caller="example.go:121" temperature=-4
+	// level=panic msg="It's over 9000!" caller="example.go:121" animal=orca size=9009
+	// level=error msg="The ice breaks!" caller="asm_amd64.s:522" err_animal=orca err_level=panic err_message="It's over 9000!" err_size=9009 number=100 omg=true
 }

--- a/example_hook_test.go
+++ b/example_hook_test.go
@@ -37,7 +37,7 @@ func Example_hook() {
 	}).Error("The ice breaks!")
 
 	// Output:
-	// level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
-	// level=warning msg="The group's number increased tremendously!" number=122 omg=true
-	// level=error msg="The ice breaks!" number=100 omg=true
+	// level=info msg="A group of walrus emerges from the ocean" caller="example.go:121" animal=walrus size=10
+	// level=warning msg="The group's number increased tremendously!" caller="example.go:121" number=122 omg=true
+	// level=error msg="The ice breaks!" caller="example.go:121" number=100 omg=true
 }

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -13,9 +13,10 @@ type FieldMap map[fieldKey]string
 
 // Default key names for the default fields
 const (
-	FieldKeyMsg   = "msg"
-	FieldKeyLevel = "level"
-	FieldKeyTime  = "time"
+	FieldKeyMsg    = "msg"
+	FieldKeyCaller = "caller"
+	FieldKeyLevel  = "level"
+	FieldKeyTime   = "time"
 )
 
 func (f FieldMap) resolve(key fieldKey) string {
@@ -83,6 +84,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		data[f.FieldMap.resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
 	}
 	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
+	data[f.FieldMap.resolve(FieldKeyCaller)] = entry.Caller
 	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
 
 	var b *bytes.Buffer

--- a/json_formatter_test.go
+++ b/json_formatter_test.go
@@ -167,8 +167,8 @@ func TestFieldsInNestedDictionary(t *testing.T) {
 	}
 
 	logEntry := WithFields(Fields{
-		"level":      "level",
-		"test":		  "test",
+		"level": "level",
+		"test":  "test",
 	})
 	logEntry.Level = InfoLevel
 

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -64,6 +64,7 @@ func TestPrint(t *testing.T) {
 	}, func(fields Fields) {
 		assert.Equal(t, fields["msg"], "test")
 		assert.Equal(t, fields["level"], "info")
+		assert.Equal(t, fields["caller"], "logrus_test.go:63")
 	})
 }
 
@@ -73,6 +74,7 @@ func TestInfo(t *testing.T) {
 	}, func(fields Fields) {
 		assert.Equal(t, fields["msg"], "test")
 		assert.Equal(t, fields["level"], "info")
+		assert.Equal(t, fields["caller"], "logrus_test.go:73")
 	})
 }
 
@@ -285,7 +287,7 @@ func TestDoubleLoggingDoesntPrefixPreviousFields(t *testing.T) {
 
 	err := json.Unmarshal(buffer.Bytes(), &fields)
 	assert.NoError(t, err, "should have decoded first message")
-	assert.Equal(t, len(fields), 4, "should only have msg/time/level/context fields")
+	assert.Equal(t, len(fields), 5, "should only have msg/time/level/caller/context fields")
 	assert.Equal(t, fields["msg"], "looks delicious")
 	assert.Equal(t, fields["context"], "eating raw fish")
 
@@ -295,7 +297,7 @@ func TestDoubleLoggingDoesntPrefixPreviousFields(t *testing.T) {
 
 	err = json.Unmarshal(buffer.Bytes(), &fields)
 	assert.NoError(t, err, "should have decoded second message")
-	assert.Equal(t, len(fields), 4, "should only have msg/time/level/context fields")
+	assert.Equal(t, len(fields), 5, "should only have msg/time/level/calller/context fields")
 	assert.Equal(t, fields["msg"], "omg it is!")
 	assert.Equal(t, fields["context"], "eating raw fish")
 	assert.Nil(t, fields["fields.msg"], "should not have prefixed previous `msg` entry")

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -122,6 +122,9 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	if entry.Message != "" {
 		fixedKeys = append(fixedKeys, f.FieldMap.resolve(FieldKeyMsg))
 	}
+	if entry.Caller != "" {
+		fixedKeys = append(fixedKeys, f.FieldMap.resolve(FieldKeyCaller))
+	}
 
 	if !f.DisableSorting {
 		if f.SortingFunc == nil {
@@ -164,6 +167,8 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 				value = entry.Level.String()
 			case f.FieldMap.resolve(FieldKeyMsg):
 				value = entry.Message
+			case f.FieldMap.resolve(FieldKeyCaller):
+				value = entry.Caller
 			default:
 				value = entry.Data[key]
 			}
@@ -196,13 +201,14 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *Entry, keys []strin
 	// Remove a single newline if it already exists in the message to keep
 	// the behavior of logrus text_formatter the same as the stdlib log package
 	entry.Message = strings.TrimSuffix(entry.Message, "\n")
+	entry.Caller = strings.TrimSuffix(entry.Caller, "\n")
 
 	if f.DisableTimestamp {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %-44s ", levelColor, levelText, entry.Message)
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %-44s %-44s", levelColor, levelText, entry.Message, entry.Caller)
 	} else if !f.FullTimestamp {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s ", levelColor, levelText, int(entry.Time.Sub(baseTimestamp)/time.Second), entry.Message)
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s %-44s", levelColor, levelText, int(entry.Time.Sub(baseTimestamp)/time.Second), entry.Message, entry.Caller)
 	} else {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, entry.Time.Format(timestampFormat), entry.Message)
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s %-44s", levelColor, levelText, entry.Time.Format(timestampFormat), entry.Message, entry.Caller)
 	}
 	for _, k := range keys {
 		v := entry.Data[k]


### PR DESCRIPTION
* Add a `caller` filed to entry to capture
where the log call came from and formats it for output.