### PR TITLE
Set caller offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 __Note: This repo forked from [sirupsen/logrus](https://github.com/sirupsen/logrus), And add some features as below:__ 
 
-- Add [`Caller`](https://github.com/barryz/logrus/pull/1) field for entry to capture  capture where the log call came from and formats it for output.
+- Add [`Caller`](https://github.com/barryz/logrus/pull/1) field for entry to capture where the log call came from and formats it for output.
 
 - Change import path prefix to `github.com/barryz/logrus...`
 

--- a/entry.go
+++ b/entry.go
@@ -12,6 +12,14 @@ import (
 	"time"
 )
 
+// skipFrameCount calling depth:
+// 0. it's runtime.Caller self invocation.
+// 1. content() invocation.
+// 2. entry.log() invocation.
+// 3. entry.Info/Infof/Infoln/Error() ... entry instance invocation.
+// 4. logger.Info/Infof/Infoln/Error() ... logger instance invocation.
+const skipFrameCount = 4
+
 var bufferPool *sync.Pool
 
 func init() {
@@ -115,7 +123,13 @@ func (entry Entry) log(level Level, msg string) {
 
 	entry.Level = level
 	entry.Message = msg
-	entry.Caller = context()
+
+	// Info level log does not need to print caller information
+	defer entry.Logger.resetCallerOffset()
+	if entry.Level != InfoLevel {
+		depth := entry.Logger.getCallerOffset() + skipFrameCount
+		entry.Caller = context(depth)
+	}
 
 	entry.fireHooks()
 
@@ -132,8 +146,12 @@ func (entry Entry) log(level Level, msg string) {
 	// panic() to use in Entry#Panic(), we avoid the allocation by checking
 	// directly here.
 	if level <= PanicLevel {
+		// In order to prevent subsequent logging getting an incorrect offset.
+		// We must reset the offset before the panic.
+		entry.Logger.resetCallerOffset()
 		panic(&entry)
 	}
+
 }
 
 func (entry *Entry) fireHooks() {
@@ -166,7 +184,9 @@ func (entry *Entry) Debug(args ...interface{}) {
 }
 
 func (entry *Entry) Print(args ...interface{}) {
-	entry.Info(args...)
+	if entry.Logger.IsLevelEnabled(InfoLevel) {
+		entry.log(InfoLevel, fmt.Sprint(args...))
+	}
 }
 
 func (entry *Entry) Info(args ...interface{}) {
@@ -182,7 +202,9 @@ func (entry *Entry) Warn(args ...interface{}) {
 }
 
 func (entry *Entry) Warning(args ...interface{}) {
-	entry.Warn(args...)
+	if entry.Logger.IsLevelEnabled(WarnLevel) {
+		entry.log(WarnLevel, fmt.Sprint(args...))
+	}
 }
 
 func (entry *Entry) Error(args ...interface{}) {
@@ -209,94 +231,102 @@ func (entry *Entry) Panic(args ...interface{}) {
 
 func (entry *Entry) Debugf(format string, args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(DebugLevel) {
-		entry.Debug(fmt.Sprintf(format, args...))
+		entry.log(DebugLevel, fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Infof(format string, args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(InfoLevel) {
-		entry.Info(fmt.Sprintf(format, args...))
+		entry.log(InfoLevel, fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Printf(format string, args ...interface{}) {
-	entry.Infof(format, args...)
+	if entry.Logger.IsLevelEnabled(InfoLevel) {
+		entry.log(InfoLevel, fmt.Sprintf(format, args...))
+	}
 }
 
 func (entry *Entry) Warnf(format string, args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(WarnLevel) {
-		entry.Warn(fmt.Sprintf(format, args...))
+		entry.log(WarnLevel, fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Warningf(format string, args ...interface{}) {
-	entry.Warnf(format, args...)
+	entry.log(WarnLevel, fmt.Sprintf(format, args...))
 }
 
 func (entry *Entry) Errorf(format string, args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(ErrorLevel) {
-		entry.Error(fmt.Sprintf(format, args...))
+		entry.log(ErrorLevel, fmt.Sprintf(format, args...))
 	}
 }
 
 func (entry *Entry) Fatalf(format string, args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(FatalLevel) {
-		entry.Fatal(fmt.Sprintf(format, args...))
+		entry.log(FatalLevel, fmt.Sprintf(format, args...))
 	}
 	Exit(1)
 }
 
 func (entry *Entry) Panicf(format string, args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(PanicLevel) {
-		entry.Panic(fmt.Sprintf(format, args...))
+		entry.log(PanicLevel, fmt.Sprintf(format, args...))
 	}
+	panic(fmt.Sprintf(format, args...))
 }
 
 // Entry Println family functions
 
 func (entry *Entry) Debugln(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(DebugLevel) {
-		entry.Debug(entry.sprintlnn(args...))
+		entry.log(DebugLevel, entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Infoln(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(InfoLevel) {
-		entry.Info(entry.sprintlnn(args...))
+		entry.log(InfoLevel, entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Println(args ...interface{}) {
-	entry.Infoln(args...)
+	if entry.Logger.IsLevelEnabled(InfoLevel) {
+		entry.log(InfoLevel, entry.sprintlnn(args...))
+	}
 }
 
 func (entry *Entry) Warnln(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(WarnLevel) {
-		entry.Warn(entry.sprintlnn(args...))
+		entry.log(WarnLevel, entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Warningln(args ...interface{}) {
-	entry.Warnln(args...)
+	if entry.Logger.IsLevelEnabled(WarnLevel) {
+		entry.log(WarnLevel, entry.sprintlnn(args...))
+	}
 }
 
 func (entry *Entry) Errorln(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(ErrorLevel) {
-		entry.Error(entry.sprintlnn(args...))
+		entry.log(ErrorLevel, entry.sprintlnn(args...))
 	}
 }
 
 func (entry *Entry) Fatalln(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(FatalLevel) {
-		entry.Fatal(entry.sprintlnn(args...))
+		entry.log(FatalLevel, entry.sprintlnn(args...))
 	}
 	Exit(1)
 }
 
 func (entry *Entry) Panicln(args ...interface{}) {
 	if entry.Logger.IsLevelEnabled(PanicLevel) {
-		entry.Panic(entry.sprintlnn(args...))
+		entry.log(PanicLevel, entry.sprintlnn(args...))
 	}
+	panic(entry.sprintlnn(args...))
 }
 
 // Sprintlnn => Sprint no newline. This is to get the behavior of how
@@ -309,10 +339,10 @@ func (entry *Entry) sprintlnn(args ...interface{}) string {
 }
 
 // Captures where the log call came from and formats it for output.
-func context() string {
-	if _, file, line, ok := runtime.Caller(4); ok {
+func context(depth int) string {
+	if _, file, line, ok := runtime.Caller(depth); ok {
 		return strings.Join([]string{filepath.Base(file), strconv.Itoa(line)}, ":")
 	}
 
-	return "unavailable"
+	return "???:0"
 }

--- a/example_basic_test.go
+++ b/example_basic_test.go
@@ -62,10 +62,67 @@ func Example_basic() {
 	}).Panic("It's over 9000!")
 
 	// Output:
-	// level=debug msg="Started observing beach" caller="example.go:121" animal=walrus number=8
-	// level=info msg="A group of walrus emerges from the ocean" caller="example.go:121" animal=walrus size=10
-	// level=warning msg="The group's number increased tremendously!" caller="example.go:121" number=122 omg=true
-	// level=debug msg="Temperature changes" caller="example.go:121" temperature=-4
-	// level=panic msg="It's over 9000!" caller="example.go:121" animal=orca size=9009
-	// level=error msg="The ice breaks!" caller="asm_amd64.s:522" err_animal=orca err_level=panic err_message="It's over 9000!" err_size=9009 number=100 omg=true
+	// level=debug msg="Started observing beach" caller="example_basic_test.go:43" animal=walrus number=8
+	// level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
+	// level=warning msg="The group's number increased tremendously!" caller="example_basic_test.go:53" number=122 omg=true
+	// level=debug msg="Temperature changes" caller="example_basic_test.go:57" temperature=-4
+	// level=panic msg="It's over 9000!" caller="example_basic_test.go:62" animal=orca size=9009
+	// level=error msg="The ice breaks!" caller="example_basic_test.go:36" err_animal=orca err_level=panic err_message="It's over 9000!" err_size=9009 number=100 omg=true
+}
+
+func Example_exported_basic() {
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(os.Stdout)
+	logrus.SetFormatter(&logrus.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
+	})
+
+	defer func() {
+		err := recover()
+		if err != nil {
+			entry := err.(*logrus.Entry)
+			logrus.WithFields(logrus.Fields{
+				"omg":         true,
+				"err_animal":  entry.Data["animal"],
+				"err_size":    entry.Data["size"],
+				"err_level":   entry.Level,
+				"err_message": entry.Message,
+				"number":      100,
+			}).Error("The ice breaks!") // or use Fatal() to force the process to exit with a nonzero code
+		}
+	}()
+
+	logrus.WithFields(logrus.Fields{
+		"animal": "walrus",
+		"size":   10,
+	}).Info("A group of walrus emerges from the ocean")
+
+	logrus.WithFields(logrus.Fields{
+		"animal": "walrus",
+		"number": 8,
+	}).Debug("Started observing beach")
+
+	logrus.WithFields(logrus.Fields{
+		"omg":    true,
+		"number": 122,
+	}).Warn("The group's number increased tremendously!")
+
+	logrus.WithFields(logrus.Fields{
+		"temperature": -4,
+	}).Debug("Temperature changes")
+
+	logrus.WithFields(logrus.Fields{
+		"animal": "orca",
+		"size":   9009,
+	}).Panic("It's over 9000!")
+
+	// Output:
+	// level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
+	// level=debug msg="Started observing beach" caller="example_basic_test.go:104" animal=walrus number=8
+	// level=warning msg="The group's number increased tremendously!" caller="example_basic_test.go:109" number=122 omg=true
+	// level=debug msg="Temperature changes" caller="example_basic_test.go:113" temperature=-4
+	// level=panic msg="It's over 9000!" caller="example_basic_test.go:118" animal=orca size=9009
+	// level=error msg="The ice breaks!" caller="example_basic_test.go:92" err_animal=orca err_level=panic err_message="It's over 9000!" err_size=9009 number=100 omg=true
+
 }

--- a/example_hook_test.go
+++ b/example_hook_test.go
@@ -37,7 +37,7 @@ func Example_hook() {
 	}).Error("The ice breaks!")
 
 	// Output:
-	// level=info msg="A group of walrus emerges from the ocean" caller="example.go:121" animal=walrus size=10
-	// level=warning msg="The group's number increased tremendously!" caller="example.go:121" number=122 omg=true
-	// level=error msg="The ice breaks!" caller="example.go:121" number=100 omg=true
+	// level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
+	// level=warning msg="The group's number increased tremendously!" caller="example_hook_test.go:32" number=122 omg=true
+	// level=error msg="The ice breaks!" caller="example_hook_test.go:37" number=100 omg=true
 }

--- a/exported.go
+++ b/exported.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// std is the name of the standard logger in stdlib `log`
-	std = New()
+	std = newExportedStdLogger()
 )
 
 func StandardLogger() *Logger {
@@ -46,6 +46,7 @@ func AddHook(hook Hook) {
 
 // WithError creates an entry from the standard logger and adds an error to it, using the value defined in ErrorKey as key.
 func WithError(err error) *Entry {
+	std.decrCallerOffset()
 	return std.WithField(ErrorKey, err)
 }
 
@@ -55,6 +56,7 @@ func WithError(err error) *Entry {
 // Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal
 // or Panic on the Entry it returns.
 func WithField(key string, value interface{}) *Entry {
+	std.decrCallerOffset()
 	return std.WithField(key, value)
 }
 
@@ -65,6 +67,7 @@ func WithField(key string, value interface{}) *Entry {
 // Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal
 // or Panic on the Entry it returns.
 func WithFields(fields Fields) *Entry {
+	std.decrCallerOffset()
 	return std.WithFields(fields)
 }
 
@@ -74,6 +77,7 @@ func WithFields(fields Fields) *Entry {
 // Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal
 // or Panic on the Entry it returns.
 func WithTime(t time.Time) *Entry {
+	std.decrCallerOffset()
 	return std.WithTime(t)
 }
 

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -84,7 +84,9 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		data[f.FieldMap.resolve(FieldKeyTime)] = entry.Time.Format(timestampFormat)
 	}
 	data[f.FieldMap.resolve(FieldKeyMsg)] = entry.Message
-	data[f.FieldMap.resolve(FieldKeyCaller)] = entry.Caller
+	if entry.Caller != "" {
+		data[f.FieldMap.resolve(FieldKeyCaller)] = entry.Caller
+	}
 	data[f.FieldMap.resolve(FieldKeyLevel)] = entry.Level.String()
 
 	var b *bytes.Buffer

--- a/logger.go
+++ b/logger.go
@@ -133,6 +133,7 @@ func (logger *Logger) getCallerOffset() int {
 // while getting file name and line number.
 func (logger *Logger) SetCallerOffset(offset int) {
 	logger.originCallerOffset = int32(offset)
+	logger.resetCallerOffset()
 }
 
 // Adds a field to the log entry, note that it doesn't log until you call

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -64,7 +64,6 @@ func TestPrint(t *testing.T) {
 	}, func(fields Fields) {
 		assert.Equal(t, fields["msg"], "test")
 		assert.Equal(t, fields["level"], "info")
-		assert.Equal(t, fields["caller"], "")
 	})
 }
 
@@ -74,7 +73,6 @@ func TestInfo(t *testing.T) {
 	}, func(fields Fields) {
 		assert.Equal(t, fields["msg"], "test")
 		assert.Equal(t, fields["level"], "info")
-		assert.Equal(t, fields["caller"], "")
 	})
 }
 
@@ -84,7 +82,7 @@ func TestWarn(t *testing.T) {
 	}, func(fields Fields) {
 		assert.Equal(t, fields["msg"], "test")
 		assert.Equal(t, fields["level"], "warning")
-		assert.Equal(t, fields["caller"], "logrus_test.go:83")
+		assert.Equal(t, fields["caller"], "logrus_test.go:81")
 	})
 }
 
@@ -288,7 +286,7 @@ func TestDoubleLoggingDoesntPrefixPreviousFields(t *testing.T) {
 
 	err := json.Unmarshal(buffer.Bytes(), &fields)
 	assert.NoError(t, err, "should have decoded first message")
-	assert.Equal(t, len(fields), 5, "should only have msg/time/level/caller/context fields")
+	assert.Equal(t, len(fields), 4, "should only have msg/time/level/caller/context fields")
 	assert.Equal(t, fields["msg"], "looks delicious")
 	assert.Equal(t, fields["context"], "eating raw fish")
 

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -64,7 +64,7 @@ func TestPrint(t *testing.T) {
 	}, func(fields Fields) {
 		assert.Equal(t, fields["msg"], "test")
 		assert.Equal(t, fields["level"], "info")
-		assert.Equal(t, fields["caller"], "logrus_test.go:63")
+		assert.Equal(t, fields["caller"], "")
 	})
 }
 
@@ -74,7 +74,7 @@ func TestInfo(t *testing.T) {
 	}, func(fields Fields) {
 		assert.Equal(t, fields["msg"], "test")
 		assert.Equal(t, fields["level"], "info")
-		assert.Equal(t, fields["caller"], "logrus_test.go:73")
+		assert.Equal(t, fields["caller"], "")
 	})
 }
 
@@ -84,6 +84,7 @@ func TestWarn(t *testing.T) {
 	}, func(fields Fields) {
 		assert.Equal(t, fields["msg"], "test")
 		assert.Equal(t, fields["level"], "warning")
+		assert.Equal(t, fields["caller"], "logrus_test.go:83")
 	})
 }
 


### PR DESCRIPTION

* add caller offset when recording log caller.
* reset caller offset when setting original caller offset firstly.
* fix typos.
* if calller is emtpy, json format will ignore this field.